### PR TITLE
Adding more pre-processing filters for Mutect.

### DIFF
--- a/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/MateRescueFilter.scala
+++ b/avocado-core/src/main/scala/org/bdgenomics/avocado/preprocessing/MateRescueFilter.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.avocado.preprocessing
+
+import org.apache.commons.configuration.SubnodeConfiguration
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.adam.rich.RichAlignmentRecord._
+
+object MateRescueFilter extends PreprocessingStage {
+  override val stageName: String = "mate_rescue_filter"
+
+  override def apply(rdd: RDD[AlignmentRecord], config: SubnodeConfiguration): RDD[AlignmentRecord] =
+    rdd.filter {
+      case record =>
+        !record.tags.exists(a => a.tag == "XT" && a.value == "M")
+    }
+}


### PR DESCRIPTION
Adds a few more pre-processing filters that @tdanford had been working on. I think we still need two more:
- Read pair agreement filter
- Mismatch quality score filter

@tdanford had some WIP code for that, but I think they need a bit more work, so I'll add them in a future PR.
