### PR TITLE
Add dbsnp to mutect caller

### DIFF
--- a/avocado-core/src/test/scala/org/bdgenomics/avocado/discovery/ReadExplorerSuite.scala
+++ b/avocado-core/src/test/scala/org/bdgenomics/avocado/discovery/ReadExplorerSuite.scala
@@ -140,7 +140,7 @@ class ReadExplorerSuite extends AvocadoFunSuite {
       .setSequence("ACTGA")
       .setQual(":::?:")
       .setCigar("1M2I2M")
-      .setMismatchingPositions("3C1")
+      .setMismatchingPositions("1C1")
       .setRecordGroupSample("sample1")
       .build()
 


### PR DESCRIPTION
Applies the sites file to the _correct_ algorithm ;). Also, fixes a compile error introduced by an upstream change in ADAM (https://github.com/bigdatagenomics/adam/pull/748). This in turn made me realize that there was a subtle issue in how we were parsing MD tags for inserts (MD tags disregard the inserted bases), so I fixed that too.
